### PR TITLE
feat: add doublons data and endpoints

### DIFF
--- a/migrations/2026-05-21-000000_add_siren_doublons/down.sql
+++ b/migrations/2026-05-21-000000_add_siren_doublons/down.sql
@@ -1,0 +1,5 @@
+DELETE FROM "public"."group_metadata"
+    WHERE "group_type" = 'siren_doublons';
+
+DROP TABLE "public"."siren_doublons" CASCADE;
+DROP TABLE "public"."siren_doublons_staging" CASCADE;

--- a/migrations/2026-05-21-000000_add_siren_doublons/up.sql
+++ b/migrations/2026-05-21-000000_add_siren_doublons/up.sql
@@ -1,0 +1,16 @@
+INSERT INTO "public"."group_metadata"
+    ("group_type", "insee_name", "file_name", "url")
+VALUES
+    ('siren_doublons', 'Siren Doublons', 'StockDoublons_utf8', 'https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockDoublons_utf8.zip');
+
+CREATE TABLE "public"."siren_doublons"
+(
+    "id" BIGSERIAL PRIMARY KEY,
+    "siren_doublon" varchar(9) NOT NULL,
+    "siren" varchar(9) NOT NULL,
+    "date_dernier_traitement" date
+);
+
+CREATE INDEX "siren_doublons_lookup_index" ON "public"."siren_doublons" USING BTREE ("siren_doublon", "date_dernier_traitement" DESC NULLS LAST);
+
+CREATE TABLE "public"."siren_doublons_staging" (LIKE "public"."siren_doublons" INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING IDENTITY INCLUDING INDEXES INCLUDING GENERATED);

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/design.md
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/design.md
@@ -1,0 +1,70 @@
+## Context
+
+L'API expose deux endpoints principaux : `GET /v3/etablissements/<siret>` et `GET /v3/unites_legales/<siren>`. Quand une entité n'existe pas en base, l'API retourne 404. L'INSEE publie un fichier `StockDoublons_utf8.zip` qui recense les SIREN devenus des doublons (absorptions, fusions) avec leur SIREN canonique. Ce fichier suit le même format ZIP/CSV que les autres fichiers stock (StockEtablissement, StockUniteLegale). Le pipeline d'ingestion existant est orchestré via `GroupType` → `UpdatableModel` → actions UpdateData / SwapData / SyncInsee.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ingérer `StockDoublons_utf8.zip` dans le pipeline existant (UpdateData + SwapData uniquement)
+- Retourner 301 vers la ressource canonique quand un SIREN doublon est demandé (établissement siège ou unité légale)
+- Retourner 404 inchangé quand le SIREN n'est pas non plus dans les doublons
+
+**Non-Goals:**
+- Synchronisation quotidienne via l'API INSEE pour les doublons (pas d'API delta disponible)
+- Modifier le comportement des endpoints de recherche (search)
+- Suivre les doublons en chaîne (siren doublon d'un doublon)
+
+## Decisions
+
+### 1. Réutiliser le pipeline `GroupType` / `UpdatableModel`
+
+Ajouter `GroupType::SirenDoublons` et `SyntheticGroupType::SirenDoublons` en suivant exactement le pattern `LiensSuccession`. `SirenDoublonModel` implémente `UpdatableModel` avec `update_daily_data` et `get_total_count` en no-op (retour immédiat) et `get_last_insee_synced_timestamp` retournant `None` (ce qui fait passer `SyncInseeAction` silencieusement).
+
+**Alternative rejetée** : table gérée hors pipeline, rechargée manuellement. Rejeté car ça crée un chemin de mise à jour séparé difficile à monitorer et qui ne bénéficie pas du mécanisme staging/swap.
+
+### 2. Pattern staging + swap pour la table `siren_doublons`
+
+Suivre le pattern existant : table `siren_doublons_staging` pour l'ingestion, swap vers `siren_doublons` (truncate + insert from staging). Cela garantit que le swap est atomique et que les vérifications de cohérence (count ±1%) s'appliquent.
+
+**Alternative rejetée** : truncate + reload direct sans staging. Rejeté car expose une fenêtre pendant laquelle la table est vide, et perd les garanties du swap.
+
+### 3. `SyntheticGroupType::All` inclut `SirenDoublons`
+
+Ajouter `GroupType::SirenDoublons` dans le `Vec` retourné par `All`. Ajouter aussi `CmdGroupType::SirenDoublons` pour permettre une mise à jour ciblée.
+
+### 4. Lookup doublon dans le handler, pas dans la couche model
+
+La logique "si NotFound → chercher doublon → redirect 301" est une responsabilité de routage. Elle reste dans `runner/etablissements.rs` et `runner/unites_legales.rs`, après avoir capturé l'erreur NotFound. La couche model expose uniquement `models::siren_doublon::find_canonical_siren(conn, siren) -> Result<Option<String>, Error>`.
+
+**Alternative rejetée** : intégrer la recherche de doublon dans `models::etablissement::get` / `models::unite_legale::get`. Rejeté car mélange la recherche de données et la logique de redirection, et complexifie les modèles.
+
+### 5. Réponse 301 avec header `Location`
+
+Utiliser `(StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, url)]).into_response()` dans Axum. Les variantes `Redirect::permanent` d'Axum produisent un 308, pas un 301 — construire la réponse manuellement est nécessaire.
+
+- Pour unité légale : `Location: /v3/unites_legales/{siren_canonique}`
+- Pour établissement : `Location: /v3/etablissements/{siret_siege_canonique}` (SIRET du siège de l'unité légale canonique)
+
+### 6. Migration Diesel pour la table et le seed `group_metadata`
+
+Une migration crée les tables `siren_doublons` et `siren_doublons_staging` avec les colonnes `siren_doublon` (PK VARCHAR 9), `siren_canonique` (VARCHAR 9), `date_dernier_traitement_doublon` (DATE nullable). Une deuxième migration (ou la même) insère la ligne dans `group_metadata` avec l'URL du fichier stock.
+
+## Risks / Trade-offs
+
+- **Redirect vers un siège inexistant** → Si le SIREN canonique existe dans les doublons mais n'a pas encore d'établissement siège en base (données incohérentes), le redirect 301 pointe vers une URL qui retournera elle-même 404. Mitigation : la table doublons est mise à jour en même temps que les tables établissements/unités légales dans le même workflow `All`, minimisant la fenêtre d'incohérence.
+- **Cascade doublon→doublon** → Un SIREN canonique pourrait lui-même être un doublon. Hors scope pour l'instant ; l'INSEE garantit en général un seul niveau d'indirection.
+- **Impact sur le count de `All`** → L'ajout de SirenDoublons dans le workflow `All` allonge légèrement le temps de mise à jour. Mitigation : le fichier doublons est petit (~quelques milliers de lignes).
+
+## Migration Plan
+
+1. Déployer la migration Diesel (nouvelles tables + seed `group_metadata`).
+2. Déployer le binaire avec la nouvelle logique.
+3. Lancer `update all` (ou `update siren-doublons`) pour ingérer le fichier doublons.
+4. Les redirections 301 sont actives dès que la table est peuplée.
+
+**Rollback** : revenir au binaire précédent restaure le 404 direct. La table `siren_doublons` reste mais est ignorée. Une migration de rollback supprime la table et la ligne `group_metadata`.
+
+## Open Questions
+
+- Faut-il exposer `siren_canonique` dans le corps de la réponse 404 pour les clients qui ne suivent pas les redirections ? (hors scope actuel)
+- L'URL `StockDoublons_utf8.zip` doit-elle être configurée via variable d'environnement ou seed en base comme les autres ? → Seed en base, cohérent avec le pattern existant.

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/proposal.md
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Le fichier `StockDoublons_utf8.zip` de l'INSEE répertorie les SIREN devenus des doublons (fusions, absorptions) et leur SIREN canonique de remplacement. Aujourd'hui, toute requête sur un SIREN doublon renvoie un 404 silencieux, alors que l'INSEE fournit la donnée nécessaire pour guider le client vers la bonne ressource via une redirection 301.
+
+## What Changes
+
+- Ajout de l'import du fichier `StockDoublons_utf8.zip` dans le pipeline de mise à jour existant (aux côtés des fichiers StockEtablissement et StockUniteLegale).
+- Création d'une table `siren_doublons` en base avec les colonnes `siren_doublon`, `siren_canonique` et `date_dernier_traitement_doublon`.
+- Modification du handler `GET /v3/etablissements/<siret>` : si le SIRET n'existe pas, on extrait le SIREN (9 premiers chiffres), on cherche dans `siren_doublons` ; si trouvé, on renvoie une redirection **301** vers l'établissement siège du SIREN canonique.
+- Modification du handler `GET /v3/unites_legales/<siren>` : si le SIREN n'existe pas, on cherche dans `siren_doublons` ; si trouvé, on renvoie une redirection **301** vers l'unité légale canonique.
+- Comportement 404 inchangé si le SIREN n'est pas non plus présent dans les doublons.
+
+## Capabilities
+
+### New Capabilities
+
+- `siren-doublons`: Ingestion du fichier StockDoublons et lookup SIREN→SIREN canonique, utilisé pour les redirections 301 sur les endpoints établissement et unité légale.
+
+### Modified Capabilities
+
+- `http-server-axum`: Les endpoints `/v3/etablissements/<siret>` et `/v3/unites_legales/<siren>` peuvent désormais renvoyer un **301** (en plus du 200 et du 404 existants) quand le SIREN est un doublon connu.
+
+## Impact
+
+- **Base de données** : nouvelle migration Diesel ajoutant la table `siren_doublons`.
+- **Update pipeline** : téléchargement et parsing d'un fichier CSV supplémentaire (`StockDoublons_utf8.zip`) lors des mises à jour.
+- **API** : les handlers établissement et unité légale voient leur logique de not-found enrichie d'une vérification de doublon ; le contrat de réponse reste rétrocompatible (nouveau code 301 optionnel, pas de suppression de comportement existant).
+- **Dépendances** : aucune dépendance externe nouvelle ; réutilisation de l'infrastructure de téléchargement/décompression/import CSV existante.

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/specs/http-server-axum/spec.md
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/specs/http-server-axum/spec.md
@@ -1,8 +1,5 @@
-# http-server-axum Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change migrate-from-warp-to-axum. Update Purpose after archive.
-## Requirements
 ### Requirement: HTTP Server with Axum
 
 The HTTP server SHALL be migrated from Warp to Axum while maintaining all existing endpoints and functionality.
@@ -84,4 +81,3 @@ The HTTP server SHALL be migrated from Warp to Axum while maintaining all existi
 
 - **WHEN** a POST request is made to `/admin/update/status/error` with valid API key
 - **THEN** the server sets the current update status to error
-

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/specs/siren-doublons/spec.md
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/specs/siren-doublons/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Ingestion du fichier StockDoublons dans le pipeline de mise à jour
+
+Le système SHALL ingérer le fichier `StockDoublons_utf8.zip` (colonnes `siren`, `sirenDoublon`, `dateDernierTraitementDoublon`) via le pipeline existant UpdateData + SwapData, de la même manière que les fichiers StockEtablissement et StockUniteLegale.
+
+#### Scenario: Mise à jour du stock doublons (fichier modifié)
+
+- **WHEN** l'action `update-data` est exécutée pour le groupe `siren-doublons` (ou `all`)
+- **AND** le fichier distant a une date de modification plus récente que la dernière importation
+- **THEN** le système télécharge, décompresse et insère le CSV dans la table de staging `siren_doublons_staging`
+
+#### Scenario: Mise à jour ignorée (fichier non modifié)
+
+- **WHEN** l'action `update-data` est exécutée pour le groupe `siren-doublons`
+- **AND** le fichier distant n'a pas été modifié depuis la dernière importation
+- **THEN** le système ne réimporte pas le fichier et indique "already imported"
+
+#### Scenario: Swap staging vers production
+
+- **WHEN** l'action `swap-data` est exécutée pour le groupe `siren-doublons`
+- **AND** des données ont été insérées en staging
+- **THEN** le contenu de `siren_doublons_staging` remplace celui de `siren_doublons` (truncate + insert)
+
+#### Scenario: Groupe `all` inclut les doublons
+
+- **WHEN** une mise à jour est lancée avec le groupe `all`
+- **THEN** les doublons SIREN sont mis à jour dans le même workflow que les établissements et unités légales
+
+### Requirement: Lookup d'un SIREN doublon vers son SIREN canonique
+
+Le système SHALL exposer une fonction de lookup permettant de retrouver le SIREN canonique à partir d'un SIREN doublon, utilisée en cas de ressource non trouvée sur les endpoints établissement et unité légale.
+
+#### Scenario: SIREN doublon connu
+
+- **WHEN** `find_canonical_siren` est appelé avec un SIREN présent dans `siren_doublons.siren_doublon`
+- **THEN** la fonction retourne `Some(siren_canonique)`
+
+#### Scenario: SIREN non présent dans les doublons
+
+- **WHEN** `find_canonical_siren` est appelé avec un SIREN absent de `siren_doublons`
+- **THEN** la fonction retourne `None`

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/tasks.md
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Migration base de données
 
-- [x] 1.1 Créer une migration Diesel ajoutant les tables `siren_doublons` et `siren_doublons_staging` (colonnes : `siren_doublon` VARCHAR(9) PK, `siren_canonique` VARCHAR(9) NOT NULL, `date_dernier_traitement_doublon` DATE nullable)
+- [x] 1.1 Créer une migration Diesel ajoutant les tables `siren_doublons` et `siren_doublons_staging` (colonnes : `id` BIGSERIAL PK, `siren_doublon` VARCHAR(9) NOT NULL, `siren` VARCHAR(9) NOT NULL, `date_dernier_traitement` DATE nullable)
 - [x] 1.2 Ajouter dans la même migration (ou une migration dédiée) la ligne `group_metadata` pour `SirenDoublons` avec l'URL `https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockDoublons_utf8.zip`
 - [x] 1.3 Mettre à jour `src/models/schema.rs` pour refléter les nouvelles tables (auto-généré par `diesel migration run`)
 
@@ -9,7 +9,7 @@
 - [x] 2.1 Créer `src/models/siren_doublon/mod.rs` et `src/models/siren_doublon/common.rs` avec les structs Diesel (`SirenDoublon`, `SirenDoublonStaging`)
 - [x] 2.2 Créer `src/models/siren_doublon/error.rs` avec le type d'erreur du modèle
 - [x] 2.3 Implémenter `fn find_canonical_siren(conn: &mut Connection, siren: &str) -> Result<Option<String>, Error>` dans `src/models/siren_doublon/mod.rs`
-- [x] 2.4 Implémenter `SirenDoublonModel` avec le trait `UpdatableModel` : `insert_remote_file_in_staging` (truncate staging + COPY CSV), `swap` (truncate production + insert from staging), `count` / `count_staging`, no-op pour `update_daily_data` / `get_total_count`, `None` pour `get_last_insee_synced_timestamp`
+- [x] 2.4 Implémenter `SirenDoublonModel` avec le trait `UpdatableModel` : `insert_remote_file_in_staging` (truncate staging + COPY CSV), `swap` (renommage atomique : siren_doublons → siren_doublons_temp, siren_doublons_staging → siren_doublons, truncate + rename temp → siren_doublons_staging), `count` / `count_staging`, no-op pour `update_daily_data` / `get_total_count`, `None` pour `get_last_insee_synced_timestamp`
 - [x] 2.5 Ajouter `pub mod siren_doublon;` dans `src/models/mod.rs`
 
 ## 3. Intégration pipeline `GroupType`

--- a/openspec/changes/archive/2026-05-21-siren-doublons-redirect/tasks.md
+++ b/openspec/changes/archive/2026-05-21-siren-doublons-redirect/tasks.md
@@ -1,0 +1,35 @@
+## 1. Migration base de données
+
+- [x] 1.1 Créer une migration Diesel ajoutant les tables `siren_doublons` et `siren_doublons_staging` (colonnes : `siren_doublon` VARCHAR(9) PK, `siren_canonique` VARCHAR(9) NOT NULL, `date_dernier_traitement_doublon` DATE nullable)
+- [x] 1.2 Ajouter dans la même migration (ou une migration dédiée) la ligne `group_metadata` pour `SirenDoublons` avec l'URL `https://object.files.data.gouv.fr/data-pipeline-open/siren/stock/StockDoublons_utf8.zip`
+- [x] 1.3 Mettre à jour `src/models/schema.rs` pour refléter les nouvelles tables (auto-généré par `diesel migration run`)
+
+## 2. Modèle `siren_doublon`
+
+- [x] 2.1 Créer `src/models/siren_doublon/mod.rs` et `src/models/siren_doublon/common.rs` avec les structs Diesel (`SirenDoublon`, `SirenDoublonStaging`)
+- [x] 2.2 Créer `src/models/siren_doublon/error.rs` avec le type d'erreur du modèle
+- [x] 2.3 Implémenter `fn find_canonical_siren(conn: &mut Connection, siren: &str) -> Result<Option<String>, Error>` dans `src/models/siren_doublon/mod.rs`
+- [x] 2.4 Implémenter `SirenDoublonModel` avec le trait `UpdatableModel` : `insert_remote_file_in_staging` (truncate staging + COPY CSV), `swap` (truncate production + insert from staging), `count` / `count_staging`, no-op pour `update_daily_data` / `get_total_count`, `None` pour `get_last_insee_synced_timestamp`
+- [x] 2.5 Ajouter `pub mod siren_doublon;` dans `src/models/mod.rs`
+
+## 3. Intégration pipeline `GroupType`
+
+- [x] 3.1 Ajouter `SirenDoublons` à l'enum `GroupType` dans `src/models/group_metadata/common.rs` (avec les implémentations `ToSql` / `FromSql` et `Display`)
+- [x] 3.2 Ajouter `GroupType::SirenDoublons => Box::new(SirenDoublonModel {})` dans `get_updatable_model()`
+- [x] 3.3 Ajouter `SirenDoublons` à `SyntheticGroupType` dans `src/models/update_metadata/common.rs` (ToSql/FromSql/Display + `Vec<GroupType>` pour `All` inclut `SirenDoublons`)
+- [x] 3.4 Ajouter `CmdGroupType::SirenDoublons` dans `src/commands/common.rs` et sa conversion vers `SyntheticGroupType`
+
+## 4. Handlers HTTP — redirection 301
+
+- [x] 4.1 Dans `src/commands/serve/runner/error.rs`, ajouter la variante `SirenDoublonRedirect { location: String }` au type `Error` et mapper vers une réponse `301 Moved Permanently` avec header `Location`
+- [x] 4.2 Modifier `get_unite_legale_by_siren` dans `src/commands/serve/runner/unites_legales.rs` : après avoir capturé `UniteLegaleNotFound`, appeler `models::siren_doublon::find_canonical_siren` et retourner `Err(Error::SirenDoublonRedirect { location: ... })` si un canonique est trouvé
+- [x] 4.3 Modifier `get_etablissement_by_siret` dans `src/commands/serve/runner/etablissements.rs` : après avoir capturé `EtablissementNotFound`, extraire le SIREN (9 premiers chars du SIRET), appeler `find_canonical_siren`, si trouvé récupérer le siège du SIREN canonique et retourner `Err(Error::SirenDoublonRedirect { location: /v3/etablissements/<siret_siege> })`
+- [x] 4.4 Mettre à jour les annotations `#[utoipa::path]` des deux handlers pour documenter le code 301
+
+## 5. Vérification
+
+- [x] 5.1 Vérifier que `cargo build` passe sans erreur
+- [x] 5.2 Lancer `update siren-doublons` localement et vérifier que la table `siren_doublons` est peuplée
+- [x] 5.3 Tester manuellement `GET /v3/unites_legales/<siren_doublon>` → 301 vers le SIREN canonique
+- [x] 5.4 Tester manuellement `GET /v3/etablissements/<siret_dont_siren_est_doublon>` → 301 vers le siège canonique
+- [x] 5.5 Vérifier que `GET /v3/unites_legales/<siren_inconnu>` retourne toujours 404

--- a/openspec/specs/siren-doublons/spec.md
+++ b/openspec/specs/siren-doublons/spec.md
@@ -1,0 +1,45 @@
+# siren-doublons Specification
+
+## Purpose
+TBD - created by archiving change siren-doublons-redirect. Update Purpose after archive.
+## Requirements
+### Requirement: Ingestion du fichier StockDoublons dans le pipeline de mise à jour
+
+Le système SHALL ingérer le fichier `StockDoublons_utf8.zip` (colonnes `siren`, `sirenDoublon`, `dateDernierTraitementDoublon`) via le pipeline existant UpdateData + SwapData, de la même manière que les fichiers StockEtablissement et StockUniteLegale.
+
+#### Scenario: Mise à jour du stock doublons (fichier modifié)
+
+- **WHEN** l'action `update-data` est exécutée pour le groupe `siren-doublons` (ou `all`)
+- **AND** le fichier distant a une date de modification plus récente que la dernière importation
+- **THEN** le système télécharge, décompresse et insère le CSV dans la table de staging `siren_doublons_staging`
+
+#### Scenario: Mise à jour ignorée (fichier non modifié)
+
+- **WHEN** l'action `update-data` est exécutée pour le groupe `siren-doublons`
+- **AND** le fichier distant n'a pas été modifié depuis la dernière importation
+- **THEN** le système ne réimporte pas le fichier et indique "already imported"
+
+#### Scenario: Swap staging vers production
+
+- **WHEN** l'action `swap-data` est exécutée pour le groupe `siren-doublons`
+- **AND** des données ont été insérées en staging
+- **THEN** le contenu de `siren_doublons_staging` remplace celui de `siren_doublons` (truncate + insert)
+
+#### Scenario: Groupe `all` inclut les doublons
+
+- **WHEN** une mise à jour est lancée avec le groupe `all`
+- **THEN** les doublons SIREN sont mis à jour dans le même workflow que les établissements et unités légales
+
+### Requirement: Lookup d'un SIREN doublon vers son SIREN canonique
+
+Le système SHALL exposer une fonction de lookup permettant de retrouver le SIREN canonique à partir d'un SIREN doublon, utilisée en cas de ressource non trouvée sur les endpoints établissement et unité légale.
+
+#### Scenario: SIREN doublon connu
+
+- **WHEN** `find_canonical_siren` est appelé avec un SIREN présent dans `siren_doublons.siren_doublon`
+- **THEN** la fonction retourne `Some(siren_canonique)`
+
+#### Scenario: SIREN non présent dans les doublons
+
+- **WHEN** `find_canonical_siren` est appelé avec un SIREN absent de `siren_doublons`
+- **THEN** la fonction retourne `None`

--- a/openspec/specs/siren-doublons/spec.md
+++ b/openspec/specs/siren-doublons/spec.md
@@ -1,7 +1,7 @@
 # siren-doublons Specification
 
 ## Purpose
-TBD - created by archiving change siren-doublons-redirect. Update Purpose after archive.
+Décrit les comportements attendus pour l'ingestion du fichier StockDoublons (doublons SIREN publiés par l'INSEE) dans le pipeline de mise à jour, et le lookup `find_canonical_siren` utilisé pour les redirections 301 sur les endpoints `/v3/unites_legales` et `/v3/etablissements`.
 ## Requirements
 ### Requirement: Ingestion du fichier StockDoublons dans le pipeline de mise à jour
 
@@ -23,7 +23,7 @@ Le système SHALL ingérer le fichier `StockDoublons_utf8.zip` (colonnes `siren`
 
 - **WHEN** l'action `swap-data` est exécutée pour le groupe `siren-doublons`
 - **AND** des données ont été insérées en staging
-- **THEN** le contenu de `siren_doublons_staging` remplace celui de `siren_doublons` (truncate + insert)
+- **THEN** `siren_doublons` est renommé en `siren_doublons_temp`, `siren_doublons_staging` est renommé en `siren_doublons`, et `siren_doublons_temp` est tronqué et renommé en `siren_doublons_staging` (swap atomique par renommage de tables)
 
 #### Scenario: Groupe `all` inclut les doublons
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -6,6 +6,7 @@ pub enum CmdGroupType {
     UnitesLegales,
     Etablissements,
     LiensSuccession,
+    SirenDoublons,
     All,
 }
 
@@ -15,6 +16,7 @@ impl From<CmdGroupType> for SyntheticGroupType {
             CmdGroupType::UnitesLegales => SyntheticGroupType::UnitesLegales,
             CmdGroupType::Etablissements => SyntheticGroupType::Etablissements,
             CmdGroupType::LiensSuccession => SyntheticGroupType::LiensSuccession,
+            CmdGroupType::SirenDoublons => SyntheticGroupType::SirenDoublons,
             CmdGroupType::All => SyntheticGroupType::All,
         }
     }

--- a/src/commands/serve/runner/error.rs
+++ b/src/commands/serve/runner/error.rs
@@ -1,5 +1,5 @@
 use crate::connectors::Error as ConnectorError;
-use crate::models::{etablissement, lien_succession, unite_legale, update_metadata};
+use crate::models::{etablissement, lien_succession, siren_doublon, unite_legale, update_metadata};
 use crate::update::error::Error as InternalUpdate;
 use axum::{
     Json,
@@ -24,6 +24,7 @@ custom_error! { pub Error
     LienSuccession {source: lien_succession::error::Error} = "[LienSuccession] {source}",
     Status {source: update_metadata::error::Error} = "[Status] {source}",
     SirenDoublonRedirect{location: String} = "Moved permanently to {location}",
+    SirenDoublonLookup{source: siren_doublon::error::Error} = "[SirenDoublon] {source}",
 }
 
 impl IntoResponse for Error {
@@ -39,6 +40,9 @@ impl IntoResponse for Error {
             Error::MissingApiKey => (StatusCode::UNAUTHORIZED, self.to_string()),
             Error::ApiKey => (StatusCode::UNAUTHORIZED, self.to_string()),
             Error::MissingBaseUrlForAsync => (StatusCode::BAD_REQUEST, self.to_string()),
+            Error::SirenDoublonLookup { source: _ } => {
+                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
+            }
             Error::LocalConnectionFailed { source: _ } => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }

--- a/src/commands/serve/runner/error.rs
+++ b/src/commands/serve/runner/error.rs
@@ -3,7 +3,7 @@ use crate::models::{etablissement, lien_succession, unite_legale, update_metadat
 use crate::update::error::Error as InternalUpdate;
 use axum::{
     Json,
-    http::StatusCode,
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 use custom_error::custom_error;
@@ -23,11 +23,15 @@ custom_error! { pub Error
     Etablissement {source: etablissement::error::Error} = "[Etablissement] {source}",
     LienSuccession {source: lien_succession::error::Error} = "[LienSuccession] {source}",
     Status {source: update_metadata::error::Error} = "[Status] {source}",
+    SirenDoublonRedirect{location: String} = "Moved permanently to {location}",
 }
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let (status, message) = match self {
+            Error::SirenDoublonRedirect { location } => {
+                return (StatusCode::MOVED_PERMANENTLY, [(header::LOCATION, location.as_str())]).into_response();
+            }
             Error::InvalidData => (StatusCode::BAD_REQUEST, self.to_string()),
             Error::InvalidSearchParams { message: _ } => {
                 (StatusCode::BAD_REQUEST, self.to_string())

--- a/src/commands/serve/runner/etablissements.rs
+++ b/src/commands/serve/runner/etablissements.rs
@@ -54,16 +54,18 @@ async fn get_etablissement_by_siret(
         Ok(e) => e,
         Err(EtablissementModelError::EtablissementNotFound) => {
             let siren = &siret[..9];
-            if let Some(canonical_siren) =
-                models::siren_doublon::find_canonical_siren(&mut connection, siren)
-                    .ok()
-                    .flatten()
-                && let Ok(siege) =
-                    models::etablissement::get_siege_with_siren(&mut connection, &canonical_siren)
-            {
-                return Err(Error::SirenDoublonRedirect {
-                    location: format!("/v3/etablissements/{}", siege.siret),
-                });
+            match models::siren_doublon::find_canonical_siren(&mut connection, siren) {
+                Ok(Some(canonical_siren)) => {
+                    let siege = models::etablissement::get_siege_with_siren(
+                        &mut connection,
+                        &canonical_siren,
+                    )?;
+                    return Err(Error::SirenDoublonRedirect {
+                        location: format!("/v3/etablissements/{}", siege.siret),
+                    });
+                }
+                Ok(None) => {}
+                Err(e) => return Err(Error::SirenDoublonLookup { source: e }),
             }
             return Err(Error::Etablissement {
                 source: EtablissementModelError::EtablissementNotFound,

--- a/src/commands/serve/runner/etablissements.rs
+++ b/src/commands/serve/runner/etablissements.rs
@@ -4,6 +4,7 @@ use super::common::{
 };
 use super::error::Error;
 use crate::models;
+use crate::models::etablissement::error::Error as EtablissementModelError;
 use crate::models::etablissement::common::{
     EtablissementSearchParams, EtablissementSearchResponse, EtablissementSearchResultResponse,
     EtablissementSortField,
@@ -26,6 +27,7 @@ use utoipa_axum::{router::OpenApiRouter, routes};
     responses(
         (status = 200, description = "Etablissement response", body = EtablissementResponse),
         (status = 400, description = "Invalid SIRET"),
+        (status = 301, description = "Redirect to siege of canonical SIREN"),
         (status = 404, description = "Etablissement not found")
     ),
     tag = super::common::PUBLIC_TAG
@@ -48,7 +50,27 @@ async fn get_etablissement_by_siret(
         .get()
         .map_err(|e| Error::LocalConnectionFailed { source: e })?;
 
-    let etablissement = models::etablissement::get(&mut connection, &siret)?;
+    let etablissement = match models::etablissement::get(&mut connection, &siret) {
+        Ok(e) => e,
+        Err(EtablissementModelError::EtablissementNotFound) => {
+            let siren = &siret[..9];
+            if let Some(canonical_siren) =
+                models::siren_doublon::find_canonical_siren(&mut connection, siren)
+                    .ok()
+                    .flatten()
+                && let Ok(siege) =
+                    models::etablissement::get_siege_with_siren(&mut connection, &canonical_siren)
+            {
+                return Err(Error::SirenDoublonRedirect {
+                    location: format!("/v3/etablissements/{}", siege.siret),
+                });
+            }
+            return Err(Error::Etablissement {
+                source: EtablissementModelError::EtablissementNotFound,
+            });
+        }
+        Err(e) => return Err(Error::Etablissement { source: e }),
+    };
     let unite_legale = models::unite_legale::get(&mut connection, &etablissement.siren)?;
     let etablissement_siege =
         models::etablissement::get_siege_with_siren(&mut connection, &etablissement.siren)?;

--- a/src/commands/serve/runner/unites_legales.rs
+++ b/src/commands/serve/runner/unites_legales.rs
@@ -1,6 +1,7 @@
 use super::common::{Context, UniteLegaleInnerResponse, UniteLegaleResponse};
 use super::error::Error;
 use crate::models;
+use crate::models::unite_legale::error::Error as UniteLegaleModelError;
 use crate::models::unite_legale::common::{
     UniteLegaleSearchParams, UniteLegaleSearchResponse, UniteLegaleSearchResultResponse,
     UniteLegaleSortField,
@@ -23,6 +24,7 @@ use utoipa_axum::{router::OpenApiRouter, routes};
     responses(
         (status = 200, description = "UniteLegale response", body = UniteLegaleResponse),
         (status = 400, description = "Invalid SIREN"),
+        (status = 301, description = "Redirect to canonical SIREN"),
         (status = 404, description = "UniteLegale not found")
     ),
     tag = super::common::PUBLIC_TAG
@@ -45,7 +47,24 @@ async fn get_unite_legale_by_siren(
         .get()
         .map_err(|e| Error::LocalConnectionFailed { source: e })?;
 
-    let unite_legale = models::unite_legale::get(&mut connection, &siren)?;
+    let unite_legale = match models::unite_legale::get(&mut connection, &siren) {
+        Ok(u) => u,
+        Err(UniteLegaleModelError::UniteLegaleNotFound) => {
+            if let Some(canonical_siren) =
+                models::siren_doublon::find_canonical_siren(&mut connection, &siren)
+                    .ok()
+                    .flatten()
+            {
+                return Err(Error::SirenDoublonRedirect {
+                    location: format!("/v3/unites_legales/{}", canonical_siren),
+                });
+            }
+            return Err(Error::UniteLegale {
+                source: UniteLegaleModelError::UniteLegaleNotFound,
+            });
+        }
+        Err(e) => return Err(Error::UniteLegale { source: e }),
+    };
     let etablissements = models::etablissement::get_with_siren(&mut connection, &siren)?;
     let etablissement_siege =
         models::etablissement::get_siege_with_siren(&mut connection, &unite_legale.siren)?;

--- a/src/commands/serve/runner/unites_legales.rs
+++ b/src/commands/serve/runner/unites_legales.rs
@@ -50,14 +50,14 @@ async fn get_unite_legale_by_siren(
     let unite_legale = match models::unite_legale::get(&mut connection, &siren) {
         Ok(u) => u,
         Err(UniteLegaleModelError::UniteLegaleNotFound) => {
-            if let Some(canonical_siren) =
-                models::siren_doublon::find_canonical_siren(&mut connection, &siren)
-                    .ok()
-                    .flatten()
-            {
-                return Err(Error::SirenDoublonRedirect {
-                    location: format!("/v3/unites_legales/{}", canonical_siren),
-                });
+            match models::siren_doublon::find_canonical_siren(&mut connection, &siren) {
+                Ok(Some(canonical_siren)) => {
+                    return Err(Error::SirenDoublonRedirect {
+                        location: format!("/v3/unites_legales/{}", canonical_siren),
+                    })
+                }
+                Ok(None) => {}
+                Err(e) => return Err(Error::SirenDoublonLookup { source: e }),
             }
             return Err(Error::UniteLegale {
                 source: UniteLegaleModelError::UniteLegaleNotFound,

--- a/src/models/group_metadata/common.rs
+++ b/src/models/group_metadata/common.rs
@@ -1,6 +1,7 @@
 use super::super::common::UpdatableModel;
 use super::super::etablissement::EtablissementModel;
 use super::super::lien_succession::LienSuccessionModel;
+use super::super::siren_doublon::SirenDoublonModel;
 use super::super::schema::group_metadata;
 use super::super::unite_legale::UniteLegaleModel;
 use chrono::{DateTime, Utc};
@@ -44,6 +45,7 @@ pub enum GroupType {
     UnitesLegales,
     Etablissements,
     LiensSuccession,
+    SirenDoublons,
 }
 
 impl GroupType {
@@ -52,6 +54,7 @@ impl GroupType {
             GroupType::UnitesLegales => Box::new(UniteLegaleModel {}),
             GroupType::Etablissements => Box::new(EtablissementModel {}),
             GroupType::LiensSuccession => Box::new(LienSuccessionModel {}),
+            GroupType::SirenDoublons => Box::new(SirenDoublonModel {}),
         }
     }
 }
@@ -63,6 +66,7 @@ impl ToSql<Text, Pg> for GroupType {
             GroupType::UnitesLegales => out.write_all(b"unites_legales")?,
             GroupType::Etablissements => out.write_all(b"etablissements")?,
             GroupType::LiensSuccession => out.write_all(b"liens_succession")?,
+            GroupType::SirenDoublons => out.write_all(b"siren_doublons")?,
         }
         Ok(IsNull::No)
     }
@@ -74,6 +78,7 @@ impl FromSql<Text, Pg> for GroupType {
             b"unites_legales" => Ok(GroupType::UnitesLegales),
             b"etablissements" => Ok(GroupType::Etablissements),
             b"liens_succession" => Ok(GroupType::LiensSuccession),
+            b"siren_doublons" => Ok(GroupType::SirenDoublons),
             _ => Err("Unrecognized enum variant".into()),
         }
     }
@@ -85,6 +90,7 @@ impl std::fmt::Display for GroupType {
             GroupType::UnitesLegales => write!(f, "unités légales"),
             GroupType::Etablissements => write!(f, "établissements"),
             GroupType::LiensSuccession => write!(f, "liens de succession"),
+            GroupType::SirenDoublons => write!(f, "siren doublons"),
         }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,3 +5,4 @@ pub mod lien_succession;
 pub mod schema;
 pub mod unite_legale;
 pub mod update_metadata;
+pub mod siren_doublon;

--- a/src/models/schema.rs
+++ b/src/models/schema.rs
@@ -196,6 +196,34 @@ diesel::table! {
     use diesel::sql_types::*;
     use postgis_diesel::sql_types::*;
 
+    siren_doublons (id) {
+        id -> Int8,
+        #[max_length = 9]
+        siren_doublon -> Varchar,
+        #[max_length = 9]
+        siren -> Varchar,
+        date_dernier_traitement -> Nullable<Date>,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use postgis_diesel::sql_types::*;
+
+    siren_doublons_staging (id) {
+        id -> Int8,
+        #[max_length = 9]
+        siren_doublon -> Varchar,
+        #[max_length = 9]
+        siren -> Varchar,
+        date_dernier_traitement -> Nullable<Date>,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use postgis_diesel::sql_types::*;
+
     unite_legale (siren) {
         #[max_length = 9]
         siren -> Varchar,
@@ -318,6 +346,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     group_metadata,
     lien_succession,
     lien_succession_staging,
+    siren_doublons,
+    siren_doublons_staging,
     unite_legale,
     unite_legale_staging,
     update_metadata,

--- a/src/models/siren_doublon/error.rs
+++ b/src/models/siren_doublon/error.rs
@@ -1,0 +1,6 @@
+use custom_error::custom_error;
+
+custom_error! { pub Error
+    LocalConnectionFailed{source: r2d2::Error} = "Unable to connect to local database ({source}).",
+    Database{source: diesel::result::Error} = "Unable to run some operations on siren_doublon ({source}).",
+}

--- a/src/models/siren_doublon/mod.rs
+++ b/src/models/siren_doublon/mod.rs
@@ -1,0 +1,130 @@
+pub mod error;
+
+use super::common::{Error as UpdatableError, UpdatableModel, copy_remote_zipped_csv};
+use super::schema::siren_doublons::dsl;
+use crate::connectors::{Connectors, local::Connection};
+use crate::update::utils::remote_file::RemoteFile;
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use diesel::pg::{CopyFormat, CopyHeader};
+use diesel::prelude::*;
+use diesel::sql_query;
+use error::Error;
+
+pub fn find_canonical_siren(
+    connection: &mut Connection,
+    siren_doublon: &str,
+) -> Result<Option<String>, Error> {
+    dsl::siren_doublons
+        .filter(dsl::siren_doublon.eq(siren_doublon))
+        .order(dsl::date_dernier_traitement.desc().nulls_last())
+        .select(dsl::siren)
+        .first::<String>(connection)
+        .optional()
+        .map_err(|error| error.into())
+}
+
+pub struct SirenDoublonModel {}
+
+#[async_trait]
+impl UpdatableModel for SirenDoublonModel {
+    fn count(&self, connectors: &Connectors) -> Result<i64, UpdatableError> {
+        let mut connection = connectors.local.pool.get()?;
+        dsl::siren_doublons
+            .select(diesel::dsl::count_star())
+            .first::<i64>(&mut connection)
+            .map_err(|error| error.into())
+    }
+
+    fn count_staging(&self, connectors: &Connectors) -> Result<i64, UpdatableError> {
+        use super::schema::siren_doublons_staging::dsl as staging_dsl;
+
+        let mut connection = connectors.local.pool.get()?;
+        staging_dsl::siren_doublons_staging
+            .select(diesel::dsl::count_star())
+            .first::<i64>(&mut connection)
+            .map_err(|error| error.into())
+    }
+
+    fn insert_remote_file_in_staging(
+        &self,
+        connectors: &Connectors,
+        remote_file: RemoteFile,
+    ) -> Result<bool, UpdatableError> {
+        use super::schema::siren_doublons_staging::dsl as staging_dsl;
+
+        let mut connection = connectors.local.pool.get()?;
+
+        sql_query("TRUNCATE siren_doublons_staging").execute(&mut connection)?;
+
+        diesel::copy_from(staging_dsl::siren_doublons_staging)
+            .from_raw_data(
+                (
+                    staging_dsl::siren,
+                    staging_dsl::siren_doublon,
+                    staging_dsl::date_dernier_traitement,
+                ),
+                |write| copy_remote_zipped_csv(remote_file.to_reader(), write),
+            )
+            .with_delimiter(',')
+            .with_format(CopyFormat::Csv)
+            .with_header(CopyHeader::Set(true))
+            .execute(&mut connection)
+            .map(|count| count > 0)
+            .map_err(|error| error.into())
+    }
+
+    fn swap(&self, connectors: &Connectors) -> Result<(), UpdatableError> {
+        let mut connection = connectors.local.pool.get()?;
+        connection.build_transaction().read_write().run(|conn| {
+            sql_query("ALTER TABLE siren_doublons RENAME TO siren_doublons_temp").execute(conn)?;
+            sql_query("ALTER TABLE siren_doublons_staging RENAME TO siren_doublons")
+                .execute(conn)?;
+            sql_query("ALTER TABLE siren_doublons_temp RENAME TO siren_doublons_staging")
+                .execute(conn)?;
+            sql_query("TRUNCATE siren_doublons_staging").execute(conn)?;
+            sql_query(
+                r#"
+                UPDATE group_metadata
+                SET last_imported_timestamp = staging_imported_timestamp
+                WHERE group_type = 'siren_doublons'
+                "#,
+            )
+            .execute(conn)?;
+            sql_query(
+                r#"
+                UPDATE group_metadata
+                SET staging_imported_timestamp = NULL
+                WHERE group_type = 'siren_doublons'
+                "#,
+            )
+            .execute(conn)?;
+
+            Ok(())
+        })
+    }
+
+    async fn get_total_count(
+        &self,
+        _connectors: &mut Connectors,
+        _start_timestamp: NaiveDateTime,
+    ) -> Result<u32, UpdatableError> {
+        Ok(0)
+    }
+
+    fn get_last_insee_synced_timestamp(
+        &self,
+        _connectors: &Connectors,
+    ) -> Result<Option<NaiveDateTime>, UpdatableError> {
+        Ok(None)
+    }
+
+    async fn update_daily_data(
+        &self,
+        _connectors: &mut Connectors,
+        _start_timestamp: NaiveDateTime,
+        _cursor: String,
+    ) -> Result<(Option<String>, usize), UpdatableError> {
+        Ok((None, 0))
+    }
+}

--- a/src/models/update_metadata/common.rs
+++ b/src/models/update_metadata/common.rs
@@ -58,6 +58,7 @@ pub enum SyntheticGroupType {
     UnitesLegales,
     Etablissements,
     LiensSuccession,
+    SirenDoublons,
     All,
 }
 
@@ -127,10 +128,12 @@ impl From<SyntheticGroupType> for Vec<GroupType> {
             SyntheticGroupType::UnitesLegales => vec![GroupType::UnitesLegales],
             SyntheticGroupType::Etablissements => vec![GroupType::Etablissements],
             SyntheticGroupType::LiensSuccession => vec![GroupType::LiensSuccession],
+            SyntheticGroupType::SirenDoublons => vec![GroupType::SirenDoublons],
             SyntheticGroupType::All => vec![
                 GroupType::UnitesLegales,
                 GroupType::Etablissements,
                 GroupType::LiensSuccession,
+                GroupType::SirenDoublons,
             ],
         }
     }
@@ -143,6 +146,7 @@ impl ToSql<Text, Pg> for SyntheticGroupType {
             SyntheticGroupType::UnitesLegales => out.write_all(b"unites_legales")?,
             SyntheticGroupType::Etablissements => out.write_all(b"etablissements")?,
             SyntheticGroupType::LiensSuccession => out.write_all(b"liens_succession")?,
+            SyntheticGroupType::SirenDoublons => out.write_all(b"siren_doublons")?,
             SyntheticGroupType::All => out.write_all(b"all")?,
         }
         Ok(IsNull::No)
@@ -155,6 +159,7 @@ impl FromSql<Text, Pg> for SyntheticGroupType {
             b"unites_legales" => Ok(SyntheticGroupType::UnitesLegales),
             b"etablissements" => Ok(SyntheticGroupType::Etablissements),
             b"liens_succession" => Ok(SyntheticGroupType::LiensSuccession),
+            b"siren_doublons" => Ok(SyntheticGroupType::SirenDoublons),
             b"all" => Ok(SyntheticGroupType::All),
             _ => Err("Unrecognized enum variant".into()),
         }
@@ -167,6 +172,7 @@ impl std::fmt::Display for SyntheticGroupType {
             SyntheticGroupType::UnitesLegales => write!(f, "unités légales"),
             SyntheticGroupType::Etablissements => write!(f, "établissements"),
             SyntheticGroupType::LiensSuccession => write!(f, "liens de succession"),
+            SyntheticGroupType::SirenDoublons => write!(f, "siren doublons"),
             SyntheticGroupType::All => write!(f, "all"),
         }
     }


### PR DESCRIPTION
This pull request introduces the ingestion and handling of SIREN "doublons" (duplicate SIRENs due to mergers or absorptions) into the existing data pipeline and API. It adds a new table and ingestion flow for the INSEE `StockDoublons_utf8.zip` file, and updates the API to return HTTP 301 redirects to canonical SIRENs or establishments when a doublon is requested. The changes are fully specified and documented, with new requirements, migration scripts, and test scenarios.

**Key changes include:**

**Database and Data Pipeline Integration**
- Added migrations to create the `siren_doublons` and `siren_doublons_staging` tables, along with a new entry in `group_metadata` for the doublons file. These tables track SIREN duplicates and their canonical replacements, and are integrated into the existing update pipeline with staging and swap patterns for atomic updates. [[1]](diffhunk://#diff-551459151373035743547aa9d5ad6ac55021c0950c3e654510d545e00ce4888fR1-R16) [[2]](diffhunk://#diff-af01d947274b2ddd7bdc69409d99d87829cc54803cea8c8c15e6dddc48c9c2c9R1-R5)
- Updated pipeline logic and models to support ingestion of the doublons file, lookup of canonical SIRENs, and inclusion of doublons in the "all" update workflow. [[1]](diffhunk://#diff-b8cfbda298c2ae3f1169224d2dc3160d71a6859bf720b9773190291563054705R1-R35) [[2]](diffhunk://#diff-ced11afa2fd39ad8c8beaef35b01fbefa17fa8858d6a232302c45e38ef84c83fR1-R42) [[3]](diffhunk://#diff-c3e55895a6a1618a48bd13d871287d7b54943f21a7484f1fb3655ad00c5e70d0R1-R45)

**API and HTTP Behavior**
- Modified the `/v3/unites_legales/<siren>` and `/v3/etablissements/<siret>` endpoints: if the requested SIREN/SIRET is not found but is a known doublon, the API now returns a 301 redirect to the canonical resource using the `Location` header. If the SIREN is not found in either table, a 404 is still returned. [[1]](diffhunk://#diff-99834425a596acbb767679aa0a11ec07b781f58501bc391ec9e623ca3628adc3R1-R83) [[2]](diffhunk://#diff-a8480c35345b7a598144d253a4ad88c084a0f34ea6194a5a75ef19eb0c45d204R27-R39) [[3]](diffhunk://#diff-a8480c35345b7a598144d253a4ad88c084a0f34ea6194a5a75ef19eb0c45d204R52-R65)
- Documented the new redirect behavior and scenarios in the OpenAPI specs and requirements. [[1]](diffhunk://#diff-99834425a596acbb767679aa0a11ec07b781f58501bc391ec9e623ca3628adc3R1-R83) [[2]](diffhunk://#diff-ced11afa2fd39ad8c8beaef35b01fbefa17fa8858d6a232302c45e38ef84c83fR1-R42) [[3]](diffhunk://#diff-c3e55895a6a1618a48bd13d871287d7b54943f21a7484f1fb3655ad00c5e70d0R1-R45)

**Documentation and Specification**
- Added or updated design, proposal, and requirements documentation to describe the rationale, migration plan, API contract changes, and test scenarios for the new doublon handling. [[1]](diffhunk://#diff-9bb0a188694ff4d458d353529f38656d26946f445adc615c73c49f07c0b2c021R1-R70) [[2]](diffhunk://#diff-56b2ad01b31d42f6683e3970f002a30876dc4b663e3d1ae14cd1941c43ef2651R1-R28) [[3]](diffhunk://#diff-70d64d41f00579a9ed96b212a001c8548dd8758363e1bc07f019b9e7ad6633ceR1-R2) [[4]](diffhunk://#diff-c3e55895a6a1618a48bd13d871287d7b54943f21a7484f1fb3655ad00c5e70d0R1-R45)

**Testing and Verification**
- Outlined and checked off tasks for migration, model implementation, pipeline integration, HTTP handler updates, and manual verification of the new behavior.

**Summary of the most important changes:**

**Database & Pipeline:**
- Created `siren_doublons` and `siren_doublons_staging` tables, and seeded `group_metadata` for the doublons file to support atomic ingestion and updates. [[1]](diffhunk://#diff-551459151373035743547aa9d5ad6ac55021c0950c3e654510d545e00ce4888fR1-R16) [[2]](diffhunk://#diff-af01d947274b2ddd7bdc69409d99d87829cc54803cea8c8c15e6dddc48c9c2c9R1-R5)
- Integrated doublons ingestion and lookup into the existing update pipeline and model structure, including support for atomic swap and inclusion in the "all" workflow. [[1]](diffhunk://#diff-b8cfbda298c2ae3f1169224d2dc3160d71a6859bf720b9773190291563054705R1-R35) [[2]](diffhunk://#diff-ced11afa2fd39ad8c8beaef35b01fbefa17fa8858d6a232302c45e38ef84c83fR1-R42) [[3]](diffhunk://#diff-c3e55895a6a1618a48bd13d871287d7b54943f21a7484f1fb3655ad00c5e70d0R1-R45)

**API Behavior:**
- Updated `/v3/unites_legales/<siren>` and `/v3/etablissements/<siret>` endpoints to return 301 redirects to canonical resources when a doublon is requested, falling back to 404 if not found. [[1]](diffhunk://#diff-99834425a596acbb767679aa0a11ec07b781f58501bc391ec9e623ca3628adc3R1-R83) [[2]](diffhunk://#diff-a8480c35345b7a598144d253a4ad88c084a0f34ea6194a5a75ef19eb0c45d204R27-R39) [[3]](diffhunk://#diff-a8480c35345b7a598144d253a4ad88c084a0f34ea6194a5a75ef19eb0c45d204R52-R65)

**Requirements & Documentation:**
- Added and updated requirements, design documents, and OpenAPI specs to fully describe the new doublon ingestion and redirect logic, including migration plan and test scenarios. [[1]](diffhunk://#diff-9bb0a188694ff4d458d353529f38656d26946f445adc615c73c49f07c0b2c021R1-R70) [[2]](diffhunk://#diff-56b2ad01b31d42f6683e3970f002a30876dc4b663e3d1ae14cd1941c43ef2651R1-R28) [[3]](diffhunk://#diff-70d64d41f00579a9ed96b212a001c8548dd8758363e1bc07f019b9e7ad6633ceR1-R2) [[4]](diffhunk://#diff-c3e55895a6a1618a48bd13d871287d7b54943f21a7484f1fb3655ad00c5e70d0R1-R45) [[5]](diffhunk://#diff-ced11afa2fd39ad8c8beaef35b01fbefa17fa8858d6a232302c45e38ef84c83fR1-R42) [[6]](diffhunk://#diff-b8cfbda298c2ae3f1169224d2dc3160d71a6859bf720b9773190291563054705R1-R35)